### PR TITLE
Add expense dashboard scaffolding

### DIFF
--- a/backend/src/main/java/com/example/fpapp/card/CreditCardStatement.java
+++ b/backend/src/main/java/com/example/fpapp/card/CreditCardStatement.java
@@ -1,0 +1,47 @@
+package com.example.fpapp.card;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "card_statements")
+@Data
+@NoArgsConstructor
+public class CreditCardStatement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String cardName;
+
+    private String month;
+
+    private LocalDate closingDate;
+
+    private LocalDate paymentDue;
+
+    @ElementCollection
+    @CollectionTable(name = "card_statement_items", joinColumns = @JoinColumn(name = "statement_id"))
+    private List<StatementItem> items;
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    public static class StatementItem {
+        private LocalDate date;
+        private String description;
+        private Double amount;
+    }
+}

--- a/backend/src/main/java/com/example/fpapp/card/CreditCardStatementRepository.java
+++ b/backend/src/main/java/com/example/fpapp/card/CreditCardStatementRepository.java
@@ -1,0 +1,8 @@
+package com.example.fpapp.card;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CreditCardStatementRepository extends JpaRepository<CreditCardStatement, Long> {
+}

--- a/backend/src/main/java/com/example/fpapp/expense/Expense.java
+++ b/backend/src/main/java/com/example/fpapp/expense/Expense.java
@@ -1,0 +1,31 @@
+package com.example.fpapp.expense;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "expenses")
+@Data
+@NoArgsConstructor
+public class Expense {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate date;
+
+    private Double amount;
+
+    private String category;
+
+    private String description;
+
+    private String cardName;
+}

--- a/backend/src/main/java/com/example/fpapp/expense/ExpenseRepository.java
+++ b/backend/src/main/java/com/example/fpapp/expense/ExpenseRepository.java
@@ -1,0 +1,8 @@
+package com.example.fpapp.expense;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+}

--- a/docs/expense-api.yaml
+++ b/docs/expense-api.yaml
@@ -1,0 +1,135 @@
+openapi: 3.0.3
+info:
+  title: Expense API
+  version: 1.0.0
+paths:
+  /cashflow/monthly:
+    get:
+      summary: Retrieve monthly cashflow
+      parameters:
+        - name: month
+          in: query
+          required: true
+          schema:
+            type: string
+            pattern: '^\\d{4}-\\d{2}$'
+      responses:
+        '200':
+          description: Cashflow totals for month
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  income:
+                    type: number
+                    format: float
+                  expenses:
+                    type: number
+                    format: float
+  /cards/statements:
+    get:
+      summary: List credit card statements
+      parameters:
+        - name: cardName
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of statements
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CreditCardStatement'
+  /expenses:
+    post:
+      summary: Add an expense
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Expense'
+      responses:
+        '201':
+          description: Created expense
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Expense'
+  /expenses/breakdown:
+    get:
+      summary: Expense breakdown for month
+      parameters:
+        - name: month
+          in: query
+          required: true
+          schema:
+            type: string
+            pattern: '^\\d{4}-\\d{2}$'
+      responses:
+        '200':
+          description: Category totals
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    category:
+                      type: string
+                    total:
+                      type: number
+                      format: float
+components:
+  schemas:
+    Expense:
+      type: object
+      properties:
+        id:
+          type: integer
+        date:
+          type: string
+          format: date
+        amount:
+          type: number
+          format: float
+        category:
+          type: string
+        description:
+          type: string
+        cardName:
+          type: string
+    CreditCardStatement:
+      type: object
+      properties:
+        id:
+          type: integer
+        cardName:
+          type: string
+        month:
+          type: string
+        closingDate:
+          type: string
+          format: date
+        paymentDue:
+          type: string
+          format: date
+        items:
+          type: array
+          items:
+            type: object
+            properties:
+              date:
+                type: string
+                format: date
+              description:
+                type: string
+              amount:
+                type: number
+                format: float

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,6 +7,14 @@ import { defineComponent, ref, onMounted, createApp } from 'vue';
 import { GoldenLayout, type LayoutConfig } from 'golden-layout';
 import CashFlowPanel from './components/CashFlowPanel.vue';
 
+// minimal container interface expected by Golden Layout when mounting a component
+interface GLContainer {
+  element: HTMLElement;
+}
+
+// custom constructor type to avoid relying on non-exported library types
+type GLComponentConstructor = (container: GLContainer, state?: unknown) => void;
+
 export default defineComponent({
   name: 'App',
   setup() {
@@ -30,11 +38,13 @@ export default defineComponent({
 
       const layout = new GoldenLayout(config, layoutEl.value);
 
-      layout.registerComponentConstructor('cash-flow', container => {
+      const cashFlowCtor: GLComponentConstructor = container => {
         const el = document.createElement('div');
         container.element.append(el);
         createApp(CashFlowPanel).mount(el);
-      });
+      };
+
+      layout.registerComponentConstructor('cash-flow', cashFlowCtor);
 
       layout.init();
     });

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -44,7 +44,7 @@ export default defineComponent({
         createApp(CashFlowPanel).mount(el);
       };
 
-      layout.registerComponentConstructor('cash-flow', cashFlowCtor);
+      layout.registerComponentFactoryFunction('cash-flow', cashFlowCtor);
 
       layout.init();
     });

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,38 +2,45 @@
   <div ref="layoutEl" class="layout"></div>
 </template>
 
-<script setup lang="ts">
-import { ref, onMounted, createApp } from 'vue';
+<script lang="ts">
+import { defineComponent, ref, onMounted, createApp } from 'vue';
 import { GoldenLayout, type LayoutConfig } from 'golden-layout';
 import CashFlowPanel from './components/CashFlowPanel.vue';
 
-const layoutEl = ref<HTMLDivElement | null>(null);
+export default defineComponent({
+  name: 'App',
+  setup() {
+    const layoutEl = ref<HTMLDivElement | null>(null);
 
-onMounted(() => {
-  if (!layoutEl.value) return;
+    onMounted(() => {
+      if (!layoutEl.value) return;
 
-  const config: LayoutConfig = {
-    root: {
-      type: 'row',
-      content: [
-        {
-          type: 'component',
-          componentType: 'cash-flow',
-          title: 'Cash Flow Table'
+      const config: LayoutConfig = {
+        root: {
+          type: 'row',
+          content: [
+            {
+              type: 'component',
+              componentType: 'cash-flow',
+              title: 'Cash Flow Table'
+            }
+          ]
         }
-      ]
-    }
-  };
+      };
 
-  const layout = new GoldenLayout(config, layoutEl.value);
+      const layout = new GoldenLayout(config, layoutEl.value);
 
-  layout.registerComponentFactoryFunction('cash-flow', container => {
-    const el = document.createElement('div');
-    container.element.appendChild(el);
-    createApp(CashFlowPanel).mount(el);
-  });
+      layout.registerComponentConstructor('cash-flow', container => {
+        const el = document.createElement('div');
+        container.element.append(el);
+        createApp(CashFlowPanel).mount(el);
+      });
 
-  layout.init();
+      layout.init();
+    });
+
+    return { layoutEl };
+  }
 });
 </script>
 

--- a/frontend/src/components/CardStatement.vue
+++ b/frontend/src/components/CardStatement.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="card-statement">
+    <label>
+      Card:
+      <select v-model="selected" @change="filter">
+        <option v-for="name in cardNames" :key="name" :value="name">{{ name }}</option>
+      </select>
+    </label>
+    <div class="statement-table">Statement for {{ selected }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+// In real usage, card names and statements would come from Pinia store
+const cardNames = ['Visa', 'Mastercard'];
+const selected = ref(cardNames[0]);
+
+function filter() {
+  // Placeholder for filter logic
+}
+</script>
+
+<style scoped>
+.card-statement {
+  padding: 1rem;
+}
+.statement-table {
+  margin-top: 1rem;
+}
+</style>

--- a/frontend/src/components/CardStatement.vue
+++ b/frontend/src/components/CardStatement.vue
@@ -10,16 +10,23 @@
   </div>
 </template>
 
-<script setup lang="ts">
-import { ref } from 'vue';
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
 
-// In real usage, card names and statements would come from Pinia store
-const cardNames = ['Visa', 'Mastercard'];
-const selected = ref(cardNames[0]);
+export default defineComponent({
+  name: 'CardStatement',
+  setup() {
+    // In real usage, card names and statements would come from Pinia store
+    const cardNames = ['Visa', 'Mastercard'];
+    const selected = ref(cardNames[0]);
 
-function filter() {
-  // Placeholder for filter logic
-}
+    function filter() {
+      // Placeholder for filter logic
+    }
+
+    return { cardNames, selected, filter };
+  }
+});
 </script>
 
 <style scoped>

--- a/frontend/src/components/CashFlowPanel.vue
+++ b/frontend/src/components/CashFlowPanel.vue
@@ -4,8 +4,16 @@
   </div>
 </template>
 
-<script setup lang="ts">
-// Placeholder for cash flow data
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'CashFlowPanel',
+  setup() {
+    // Placeholder for cash flow data
+    return {};
+  }
+});
 </script>
 
 <style scoped>

--- a/frontend/src/components/ExpenseBreakdown.vue
+++ b/frontend/src/components/ExpenseBreakdown.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="expense-breakdown">
+    <div class="table">Expense Breakdown Table</div>
+    <div class="chart">Pie Chart</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Placeholder: would use Pinia store for breakdown data
+</script>
+
+<style scoped>
+.expense-breakdown {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+}
+.table {
+  flex: 1;
+}
+.chart {
+  flex: 1;
+}
+</style>

--- a/frontend/src/components/ExpenseBreakdown.vue
+++ b/frontend/src/components/ExpenseBreakdown.vue
@@ -5,8 +5,16 @@
   </div>
 </template>
 
-<script setup lang="ts">
-// Placeholder: would use Pinia store for breakdown data
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'ExpenseBreakdown',
+  setup() {
+    // Placeholder: would use Pinia store for breakdown data
+    return {};
+  }
+});
 </script>
 
 <style scoped>

--- a/frontend/src/components/ExpenseInput.vue
+++ b/frontend/src/components/ExpenseInput.vue
@@ -6,16 +6,23 @@
   </form>
 </template>
 
-<script setup lang="ts">
-import { reactive } from 'vue';
+<script lang="ts">
+import { defineComponent, reactive } from 'vue';
 
-const form = reactive({ description: '', amount: 0 });
+export default defineComponent({
+  name: 'ExpenseInput',
+  setup() {
+    const form = reactive({ description: '', amount: 0 });
 
-function submit() {
-  // Placeholder: would dispatch to Pinia store
-  form.description = '';
-  form.amount = 0;
-}
+    function submit() {
+      // Placeholder: would dispatch to Pinia store
+      form.description = '';
+      form.amount = 0;
+    }
+
+    return { form, submit };
+  }
+});
 </script>
 
 <style scoped>

--- a/frontend/src/components/ExpenseInput.vue
+++ b/frontend/src/components/ExpenseInput.vue
@@ -1,0 +1,27 @@
+<template>
+  <form class="expense-input" @submit.prevent="submit">
+    <input v-model="form.description" placeholder="Description" />
+    <input v-model.number="form.amount" type="number" placeholder="Amount" />
+    <button type="submit">Add</button>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { reactive } from 'vue';
+
+const form = reactive({ description: '', amount: 0 });
+
+function submit() {
+  // Placeholder: would dispatch to Pinia store
+  form.description = '';
+  form.amount = 0;
+}
+</script>
+
+<style scoped>
+.expense-input {
+  display: flex;
+  gap: 0.5rem;
+  padding: 1rem;
+}
+</style>

--- a/frontend/src/components/MonthlyGraph.vue
+++ b/frontend/src/components/MonthlyGraph.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="monthly-graph">
+    Monthly Cashflow Graph
+  </div>
+</template>
+
+<script setup lang="ts">
+// Placeholder for monthly cashflow graph logic using Pinia store
+</script>
+
+<style scoped>
+.monthly-graph {
+  padding: 1rem;
+}
+</style>

--- a/frontend/src/components/MonthlyGraph.vue
+++ b/frontend/src/components/MonthlyGraph.vue
@@ -4,8 +4,16 @@
   </div>
 </template>
 
-<script setup lang="ts">
-// Placeholder for monthly cashflow graph logic using Pinia store
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'MonthlyGraph',
+  setup() {
+    // Placeholder for monthly cashflow graph logic using Pinia store
+    return {};
+  }
+});
 </script>
 
 <style scoped>

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/frontend/src/layouts/Dashboard.vue
+++ b/frontend/src/layouts/Dashboard.vue
@@ -1,0 +1,92 @@
+<template>
+  <div ref="layoutEl" class="dashboard-layout"></div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, createApp } from 'vue';
+import { GoldenLayout, type LayoutConfig } from 'golden-layout';
+import MonthlyGraph from '../components/MonthlyGraph.vue';
+import CardStatement from '../components/CardStatement.vue';
+import ExpenseInput from '../components/ExpenseInput.vue';
+import ExpenseBreakdown from '../components/ExpenseBreakdown.vue';
+
+const layoutEl = ref<HTMLDivElement | null>(null);
+
+onMounted(() => {
+  if (!layoutEl.value) return;
+
+  const config: LayoutConfig = {
+    root: {
+      type: 'row',
+      content: [
+        {
+          type: 'column',
+          content: [
+            {
+              type: 'component',
+              componentType: 'monthly-graph',
+              title: 'Monthly Cashflow'
+            },
+            {
+              type: 'component',
+              componentType: 'card-statement',
+              title: 'Credit Card Statement'
+            }
+          ]
+        },
+        {
+          type: 'column',
+          content: [
+            {
+              type: 'component',
+              componentType: 'expense-input',
+              title: 'Expense Input'
+            },
+            {
+              type: 'component',
+              componentType: 'expense-breakdown',
+              title: 'Expense Breakdown'
+            }
+          ]
+        }
+      ]
+    }
+  };
+
+  const layout = new GoldenLayout(config, layoutEl.value);
+
+  layout.registerComponentFactoryFunction('monthly-graph', container => {
+    const el = document.createElement('div');
+    container.element.appendChild(el);
+    createApp(MonthlyGraph).mount(el);
+  });
+
+  layout.registerComponentFactoryFunction('card-statement', container => {
+    const el = document.createElement('div');
+    container.element.appendChild(el);
+    createApp(CardStatement).mount(el);
+  });
+
+  layout.registerComponentFactoryFunction('expense-input', container => {
+    const el = document.createElement('div');
+    container.element.appendChild(el);
+    createApp(ExpenseInput).mount(el);
+  });
+
+  layout.registerComponentFactoryFunction('expense-breakdown', container => {
+    const el = document.createElement('div');
+    container.element.appendChild(el);
+    createApp(ExpenseBreakdown).mount(el);
+  });
+
+  layout.init();
+});
+</script>
+
+<style>
+html, body, .dashboard-layout {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+}
+</style>

--- a/frontend/src/layouts/Dashboard.vue
+++ b/frontend/src/layouts/Dashboard.vue
@@ -2,84 +2,91 @@
   <div ref="layoutEl" class="dashboard-layout"></div>
 </template>
 
-<script setup lang="ts">
-import { ref, onMounted, createApp } from 'vue';
+<script lang="ts">
+import { defineComponent, ref, onMounted, createApp } from 'vue';
 import { GoldenLayout, type LayoutConfig } from 'golden-layout';
 import MonthlyGraph from '../components/MonthlyGraph.vue';
 import CardStatement from '../components/CardStatement.vue';
 import ExpenseInput from '../components/ExpenseInput.vue';
 import ExpenseBreakdown from '../components/ExpenseBreakdown.vue';
 
-const layoutEl = ref<HTMLDivElement | null>(null);
+export default defineComponent({
+  name: 'Dashboard',
+  setup() {
+    const layoutEl = ref<HTMLDivElement | null>(null);
 
-onMounted(() => {
-  if (!layoutEl.value) return;
+    onMounted(() => {
+      if (!layoutEl.value) return;
 
-  const config: LayoutConfig = {
-    root: {
-      type: 'row',
-      content: [
-        {
-          type: 'column',
+      const config: LayoutConfig = {
+        root: {
+          type: 'row',
           content: [
             {
-              type: 'component',
-              componentType: 'monthly-graph',
-              title: 'Monthly Cashflow'
+              type: 'column',
+              content: [
+                {
+                  type: 'component',
+                  componentType: 'monthly-graph',
+                  title: 'Monthly Cashflow'
+                },
+                {
+                  type: 'component',
+                  componentType: 'card-statement',
+                  title: 'Credit Card Statement'
+                }
+              ]
             },
             {
-              type: 'component',
-              componentType: 'card-statement',
-              title: 'Credit Card Statement'
-            }
-          ]
-        },
-        {
-          type: 'column',
-          content: [
-            {
-              type: 'component',
-              componentType: 'expense-input',
-              title: 'Expense Input'
-            },
-            {
-              type: 'component',
-              componentType: 'expense-breakdown',
-              title: 'Expense Breakdown'
+              type: 'column',
+              content: [
+                {
+                  type: 'component',
+                  componentType: 'expense-input',
+                  title: 'Expense Input'
+                },
+                {
+                  type: 'component',
+                  componentType: 'expense-breakdown',
+                  title: 'Expense Breakdown'
+                }
+              ]
             }
           ]
         }
-      ]
-    }
-  };
+      };
 
-  const layout = new GoldenLayout(config, layoutEl.value);
+      const layout = new GoldenLayout(config, layoutEl.value);
 
-  layout.registerComponentFactoryFunction('monthly-graph', container => {
-    const el = document.createElement('div');
-    container.element.appendChild(el);
-    createApp(MonthlyGraph).mount(el);
-  });
+      layout.registerComponentConstructor('monthly-graph', container => {
+        const el = document.createElement('div');
+        container.element.append(el);
+        createApp(MonthlyGraph).mount(el);
+      });
 
-  layout.registerComponentFactoryFunction('card-statement', container => {
-    const el = document.createElement('div');
-    container.element.appendChild(el);
-    createApp(CardStatement).mount(el);
-  });
+      layout.registerComponentConstructor('card-statement', container => {
+        const el = document.createElement('div');
+        container.element.append(el);
+        createApp(CardStatement).mount(el);
+      });
 
-  layout.registerComponentFactoryFunction('expense-input', container => {
-    const el = document.createElement('div');
-    container.element.appendChild(el);
-    createApp(ExpenseInput).mount(el);
-  });
+      layout.registerComponentConstructor('expense-input', container => {
+        const el = document.createElement('div');
+        container.element.append(el);
+        createApp(ExpenseInput).mount(el);
+      });
 
-  layout.registerComponentFactoryFunction('expense-breakdown', container => {
-    const el = document.createElement('div');
-    container.element.appendChild(el);
-    createApp(ExpenseBreakdown).mount(el);
-  });
+      layout.registerComponentConstructor('expense-breakdown', container => {
+        const el = document.createElement('div');
+        container.element.append(el);
+        createApp(ExpenseBreakdown).mount(el);
+      });
 
-  layout.init();
+      layout.init();
+    });
+
+    return { layoutEl };
+  }
 });
 </script>
 


### PR DESCRIPTION
## Summary
- document cashflow, card statements, and expense APIs
- scaffold JPA entities and repositories for expenses and card statements
- add Vue components and Golden Layout dashboard for cashflow, statements, and inputs

## Testing
- `./gradlew test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f624f2d748328a397618da33d70d3