### PR TITLE
feat: add quasar dashboard layout

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,9 +2,19 @@
   <q-layout view="hHh lpR fFf">
     <q-header elevated class="bg-green-7 text-white">
       <q-toolbar>
-        <q-btn flat dense round :icon="drawer ? 'close' : 'menu'" @click="drawer = !drawer" />
+        <q-btn flat dense round @click="drawer = !drawer">
+          <transition name="rotate" mode="out-in">
+            <q-icon :key="drawer" :name="drawer ? 'close' : 'menu'" />
+          </transition>
+        </q-btn>
         <q-toolbar-title class="text-center">FPApp</q-toolbar-title>
-        <q-btn flat dense round icon="account_circle" />
+        <div class="row items-center no-wrap q-gutter-sm">
+          <q-icon name="account_circle" />
+          <div class="column items-end">
+            <div>User: ryuji</div>
+            <div>{{ currentTime }}</div>
+          </div>
+        </div>
       </q-toolbar>
     </q-header>
 
@@ -26,7 +36,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import DashboardView from './components/DashboardView.vue';
 import DataEntryView from './components/DataEntryView.vue';
 
@@ -42,5 +52,37 @@ const currentComponent = computed(() => componentMap[currentView.value]);
 
 function switchView(view: 'dashboard' | 'data-entry') {
   currentView.value = view;
+  drawer.value = false;
 }
+
+const currentTime = ref('');
+let timer: number;
+
+function updateTime() {
+  const now = new Date(Date.now() + 9 * 60 * 60 * 1000);
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(now.getUTCDate()).padStart(2, '0');
+  const h = String(now.getUTCHours()).padStart(2, '0');
+  const min = String(now.getUTCMinutes()).padStart(2, '0');
+  currentTime.value = `${y}/${m}/${d} ${h}:${min}`;
+}
+
+onMounted(() => {
+  updateTime();
+  timer = window.setInterval(updateTime, 1000);
+});
+
+onBeforeUnmount(() => {
+  clearInterval(timer);
+});
 </script>
+
+<style scoped>
+.rotate-enter-active, .rotate-leave-active {
+  transition: transform 0.2s ease;
+}
+.rotate-enter-from, .rotate-leave-to {
+  transform: rotate(180deg);
+}
+</style>

--- a/frontend/src/components/DashboardView.vue
+++ b/frontend/src/components/DashboardView.vue
@@ -1,0 +1,23 @@
+<template>
+  <q-page class="q-pa-md">
+    <q-card flat bordered class="q-pa-md">
+      <q-card-section>
+        <div class="text-h6">Mock Dashboard</div>
+      </q-card-section>
+      <q-table :rows="rows" :columns="columns" row-key="id" flat />
+    </q-card>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+const columns = [
+  { name: 'item', label: 'Item', field: 'item', align: 'left' },
+  { name: 'amount', label: 'Amount', field: 'amount', align: 'right',
+    format: (val: number) => `$${val.toFixed(2)}` }
+];
+
+const rows = [
+  { id: 1, item: 'Income', amount: 5000 },
+  { id: 2, item: 'Expenses', amount: 3000 }
+];
+</script>

--- a/frontend/src/components/DataEntryView.vue
+++ b/frontend/src/components/DataEntryView.vue
@@ -1,0 +1,22 @@
+<template>
+  <q-page class="q-pa-md">
+    <q-form @submit.prevent="onSubmit" class="q-gutter-md">
+      <q-input v-model="form.name" label="Name" />
+      <q-input v-model.number="form.amount" label="Amount" type="number" />
+      <div>
+        <q-btn label="Submit" type="submit" color="primary" />
+      </div>
+    </q-form>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const form = ref({ name: '', amount: null as number | null });
+
+function onSubmit() {
+  // mock submit handler
+  console.log('Submitted', form.value);
+}
+</script>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,7 +6,5 @@ import App from './App.vue';
 import { Quasar } from 'quasar';
 import 'quasar/src/css/index.sass';
 import '@quasar/extras/material-icons/material-icons.css';
-import 'golden-layout/dist/css/goldenlayout-base.css';
-import 'golden-layout/dist/css/themes/goldenlayout-light-theme.css';
 
 createApp(App).use(Quasar, {}).mount('#app');


### PR DESCRIPTION
## Summary
- add Quasar layout with fixed header and responsive drawer
- show dashboard table and data entry form based on menu
- streamline frontend entry by removing Golden Layout assets

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689142dc1fb08328a9059fca7fe39ae6