### PR TITLE
docs: add commit build rule to AGENTS

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -8,6 +8,10 @@ FPApp (Financial Planning Application)
 FPApp is a web-based financial planning application designed to help users visualize future cash flow, manage expenses, simulate financial scenarios, and build assets. It is intended for use by two-person households with complex income/expense structures and multiple credit cards.
 
 ---
+## ✅ Commit Rules
+- Commits may only be pushed after both the frontend (`npm run build`) and backend (`./gradlew build`) builds complete successfully with no warnings or errors. Partial builds or builds with warnings/errors must be fixed before committing.
+
+---
 
 ## 🖥️ Frontend
 - **Framework**: Vue 3


### PR DESCRIPTION
## Summary
- document commit rule requiring successful frontend and backend builds before pushing

## Testing
- `npm run build`
- `./gradlew build` *(fails: Trust store file /usr/lib/jvm/java-17-openjdk-amd64/lib/security/cacerts does not exist or is not readable)*

------
https://chatgpt.com/codex/tasks/task_e_6896bfdc1f40832884981db5dfc43ffa